### PR TITLE
Allow for passing a Kinesis partitionKey into the stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,16 @@ readFromKinesisStream[IO]("appName", "streamName")
 ```
 
 ### Publishing records to Kinesis with KPL
-A Pipe and Sink allow for writing a stream of bytes to a Kinesis stream.
+A Pipe and Sink allow for writing a stream of tuple2 (paritionKey, ByteBuffer) to a Kinesis stream.
 
 Example:
 ```scala
-someStream
-  .to(writeToKinesis_[IO]("streamName", "partitionKey"))
+Stream("testData")
+  .map { d => ("partitionKey", ByteBuffer.wrap(d.getBytes))}
+  .to(writeToKinesis_[IO]("streamName"))
 ```
+
+AWS credential chain and region can be configured by overriding the respective fields in the KinesisProducerClient parameter to `writeToKinesis`. Defaults to using the default AWS credentials chain and `us-east-1` for region.
 
 ## Kinesis Firehose
 **TODO:** Stream get data, Stream send data

--- a/src/main/scala/fs2/aws/internal/Internal.scala
+++ b/src/main/scala/fs2/aws/internal/Internal.scala
@@ -15,7 +15,7 @@ import com.amazonaws.services.kinesis.producer.{
   UserRecordResult,
   KinesisProducerConfiguration
 }
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
 import com.google.common.util.concurrent.ListenableFuture
 
 import scala.util.control.Exception
@@ -47,12 +47,13 @@ object Internal {
 
   private[aws] trait KinesisProducerClient[F[_]] {
 
-    val credentials = new DefaultAWSCredentialsProviderChain()
-    val region      = "us-east-1"
+    val credentials: AWSCredentialsProviderChain = new DefaultAWSCredentialsProviderChain()
+    val region: Option[String]                   = None
 
     private lazy val config: KinesisProducerConfiguration = new KinesisProducerConfiguration()
       .setCredentialsProvider(credentials)
-      .setRegion(region)
+
+    region.map(r => config.setRegion(r))
 
     private lazy val client = new KinesisProducer(config)
 

--- a/src/main/scala/fs2/aws/internal/Internal.scala
+++ b/src/main/scala/fs2/aws/internal/Internal.scala
@@ -41,11 +41,10 @@ object Internal {
   private[aws] case class MultiPartUploadInfo(uploadId: String, partETags: List[PartETag])
 
   private[aws] trait KinesisProducerClient[F[_]] {
-    implicit def byteList2ByteBuffer(l: List[Byte]): ByteBuffer = ByteBuffer.wrap(l.toArray)
 
     private lazy val client = new KinesisProducer
 
-    def putData(streamName: String, partitionKey: String, data: List[Byte])(
+    def putData(streamName: String, partitionKey: String, data: ByteBuffer)(
         implicit F: Effect[F]): F[ListenableFuture[UserRecordResult]] =
       F.delay(client.addUserRecord(streamName, partitionKey, data))
   }

--- a/src/test/scala/fs2/aws/utils/KinesisStub.scala
+++ b/src/test/scala/fs2/aws/utils/KinesisStub.scala
@@ -1,12 +1,14 @@
 package fs2
 package aws
 
+import java.nio.ByteBuffer
+
 object KinesisStub {
-  var _data: List[List[Byte]] = List()
+  var _data: List[ByteBuffer] = List()
 
   def clear() = _data = List()
 
-  def save(data: List[Byte]) = {
+  def save(data: ByteBuffer) = {
     _data = _data :+ data
   }
 }


### PR DESCRIPTION
- Pipe and Sink now accept a tuple (partitionKey, ByteBuffer)
- Aggregation of bytes will occur before being passed to writeToKinesis instead of in the stream
- Allow for overriding the AWS credentials and region for KPL client

This ultimately allows for dynamically setting the partitionKey based on the record data, as this wasn't possible the previous implementation.