### PR TITLE
Fix groupId to match Sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 name := "fs2-aws"
-organization := "io.github"
+organization := "io.github.dmateusp"
 
 scalaVersion := "2.12.7"
 


### PR DESCRIPTION
The Sonatype repo expects groupId `io.github.dmateusp`, which is why the artifact is going to central bundles and not its own bundle. This solves that.